### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/assets/stylesheets/show.css
+++ b/app/assets/stylesheets/show.css
@@ -1,0 +1,207 @@
+/* 商品の概要 */
+
+.item-show {
+  background-color: #f8f8f8;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5vh 0;
+}
+
+.item-box {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 1200px;
+  padding: 10vh 15vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.item-box>.name {
+  text-align: center;
+  font-weight: bold;
+  font-size: 25px;
+}
+
+.item-box-img {
+  height: 50vh;
+  width: 60vw;
+  min-height: 500px;
+  background-color: rgb(205, 202, 202);
+  object-fit: contain;
+}
+
+.item-price-box {
+  margin: 25px 0px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.item-price-box>.item-price {
+  font-size: 4vh;
+  font-weight: bold;
+}
+
+.item-price-box>.item-postage {
+  font-size: 16px;
+}
+
+
+.item-red-btn {
+  text-align: center;
+  background-color: #ea352d;
+  font-size: 24px;
+  font-weight: bold;
+  color: #FFF;
+  margin: 20px 0px;
+  padding: 2vh 10vw;
+}
+
+.or-text {
+  font-size: 20px;
+}
+
+.item-destroy {
+  background-color: lightgray;
+  text-align: center;
+  font-size: 24px;
+  color: black;
+  margin: 20px 0px;
+  padding: 2vh 10vw;
+}
+
+.item-explain-box {
+  font-size: 18px;
+  margin: 40px 0px;
+  overflow-wrap: anywhere;
+}
+
+.detail-table {
+  margin-bottom: 30px;
+  width: 100%;
+}
+
+.detail-item {
+  width: 20%;
+  background-color: #eee;
+  border: 1px solid #dedede;
+  font-size: 14px;
+  text-align: center;
+}
+
+.detail-value {
+  width: 80%;
+  padding: 20px;
+  border: 1px solid #dedede;
+  font-size: 14px;
+}
+
+.option {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+}
+
+.favorite-btn {
+  border-radius: 40px;
+  width: 15vw;
+  min-width: 200px;
+  color: rgb(249, 75, 0);
+  border: 2px solid #ffb340;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+}
+
+.favorite-star-icon {
+  margin-right: 5px;
+}
+
+.report-btn {
+  border-radius: 40px;
+  width: 15vw;
+  min-width: 200px;
+
+  padding: 1vh 0;
+  color: black;
+  border: 2px solid #2d2d2d;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.report-flag-icon {
+  margin-right: 5px;
+}
+
+
+/* /商品の概要 */
+
+.comment-box {
+  width: 40vw;
+  background-color: #fff;
+  margin: 5vh 0;
+  text-align: center;
+}
+
+.comment-text {
+  width: 100%;
+  height: 100px;
+  padding: 10px;
+  border: solid 2px #dedede;
+  resize: none;
+}
+
+.comment-warn {
+  padding: 10px;
+  font-size: 14px;
+  margin: 10px 0px;
+  text-align: left;
+}
+
+.comment-btn {
+  line-height: 48px;
+  background-color: #3CCACE;
+  border: 1px solid #3CCACE;
+  color: #fff;
+  width: 50%;
+  min-width: 150px;
+  font-size: 18px;
+  border-radius: 100px;
+  margin-bottom: 2vh;
+}
+
+.comment-flag {
+  display: flex;
+  justify-content: center;
+}
+
+.comment-flag-icon {
+  margin: 10px 5px 0 0;
+}
+
+.links {
+  display: flex;
+  justify-content: space-between;
+  width: 50vw;
+
+}
+
+.change-item-btn {
+  font-size: 30px;
+  text-decoration: none;
+  color: #3CCACE;
+}
+
+.another-item {
+  display: block;
+  margin: 30px 0px 8px;
+  color: #3CCACE;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 23px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
   end
-  
+
   def create
     @item = Item.new(item_params)
     if @item.save
@@ -22,14 +22,15 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
+
   private
+
   def item_params
-    params.require(:item).permit(:item_name, :item_description, :category_id, :condition_id, :delivery_charge_id, :delivery_from_id, :delivery_time_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:item_name, :item_description, :category_id, :condition_id, :delivery_charge_id,
+                                 :delivery_from_id, :delivery_time_id, :price, :image).merge(user_id: current_user.id)
   end
 
   def set_item
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :set_item, only: [:show]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -18,9 +19,17 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+  
   private
   def item_params
     params.require(:item).permit(:item_name, :item_description, :category_id, :condition_id, :delivery_charge_id, :delivery_from_id, :delivery_time_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
-class Category < ActiveHash::Base 
+class Category < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: 'レディース' },
@@ -12,7 +12,6 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-   include ActiveHash::Associations
-   has_many :items
-  
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -6,7 +6,7 @@ class Condition < ActiveHash::Base
     { id: 4, name: '目立った傷や汚れなし' },
     { id: 5, name: 'やや傷や汚れなし' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
   include ActiveHash::Associations
   has_many :items

--- a/app/models/delivery_charge.rb
+++ b/app/models/delivery_charge.rb
@@ -2,7 +2,7 @@ class DeliveryCharge < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い（購入者負担）' },
-    { id: 3, name: '送料込み（出品者負担)' },
+    { id: 3, name: '送料込み（出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/delivery_from.rb
+++ b/app/models/delivery_from.rb
@@ -1,20 +1,20 @@
 class DeliveryFrom < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
-    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, 
+    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' },
     { id: 7, name: '山形県' }, { id: 8, name: '福島県' }, { id: 9, name: '茨城県' },
     { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
     { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' },
     { id: 16, name: '新潟県' }, { id: 17, name: '富山県' }, { id: 18, name: '石川県' },
     { id: 19, name: '福井県' }, { id: 20, name: '山梨県' }, { id: 21, name: '長野県' },
-    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, 
-    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, 
-    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, 
-    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, 
-    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, 
-    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, 
-    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, 
-    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, 
+    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' },
+    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' },
+    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' },
+    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 

--- a/app/models/delivery_time.rb
+++ b/app/models/delivery_time.rb
@@ -3,7 +3,7 @@ class DeliveryTime < ActiveHash::Base
     { id: 1, name: '---' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
   include ActiveHash::Associations
   has_many :items

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,13 +3,13 @@ class Item < ApplicationRecord
   validates :image,               presence: true
   validates :item_name,           presence: true
   validates :item_description,    presence: true
-  validates :category_id,         presence: true 
-  validates :condition_id,        presence: true 
-  validates :delivery_charge_id,  presence: true 
-  validates :delivery_from_id,    presence: true 
-  validates :delivery_time_id,    presence: true 
+  validates :category_id,         presence: true
+  validates :condition_id,        presence: true
+  validates :delivery_charge_id,  presence: true
+  validates :delivery_from_id,    presence: true
+  validates :delivery_time_id,    presence: true
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
-                      presence: {message: "can't be blank" }
+                    presence: { message: "can't be blank" }
 
   has_one_attached :image
   belongs_to :user
@@ -19,5 +19,6 @@ class Item < ApplicationRecord
   belongs_to :delivery_from
   belongs_to :delivery_time
 
-  validates :category_id, :condition_id, :delivery_charge_id, :delivery_from_id, :delivery_time_id, numericality: { other_than: 1 , message: "can't be blank"} 
+  validates :category_id, :condition_id, :delivery_charge_id, :delivery_from_id, :delivery_time_id,
+            numericality: { other_than: 1, message: "can't be blank" }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,6 @@
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to item_path(item.id) do %>
-        
         <div class='item-info'>
           <%= image_tag item.image.variant(resize_to_fill: [260, 250]) %>
           <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -118,9 +118,8 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
+
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -171,7 +170,7 @@
   <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
+  
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
   <% unless @items[0].nil? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to item_path(item.id) do %>
         
         <div class='item-info'>
           <%= image_tag item.image.variant(resize_to_fill: [260, 250]) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
        <% end %>
    <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
     <div class="item-explain-box">
       <span><%= @item.item_description %></span>
     </div>
@@ -70,7 +70,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -94,9 +93,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,69 +1,61 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image.variant(resize_to_fill: [260, 250]), class:"item-box-img" %>
+      
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_charge.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+   <% if user_signed_in? %> 
+       <% if current_user == @item.user %> 
+            <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+            <p class="or-text">or</p>
+            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+       <% else %>
+         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+       <% end %>
+   <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_from.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   get 'items/index'
-  resources :items, only: [:index, :new, :create] do
+  resources :items, only: [:index, :new, :create, :show] do
   end  
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :item do
     association :user
     item_name          { Faker::Lorem.sentence }
-    item_description   { Faker::Lorem.sentence } 
+    item_description   { Faker::Lorem.sentence }
     category_id        { 2 }
     condition_id       { 2 }
     delivery_charge_id { 2 }
     delivery_from_id   { 2 }
     delivery_time_id   { 2 }
     price              { 700 }
-    
+
     after(:build) do |item|
       item.image.attach(io: File.open('public/20230530.png'), filename: '20230530.png', content_type: 'image/png')
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     end
     nickname              { Faker::Name.initials(number: 2) }
     email                 { Faker::Internet.free_email }
-    password              { '1a' + Faker::Internet.password(min_length: 6) } 
+    password              { '1a' + Faker::Internet.password(min_length: 6) }
     password_confirmation { password }
     first_name            { 'やマ田' }
     last_name             { '太ろウ' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,96 +3,95 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
   describe '#create' do
-  before do
-    @item = FactoryBot.build(:item)
-  end
-
-  describe '商品出品機能' do
-    context '商品出品できる場合' do
-      it '必要事項を全て過不足なく入力すると出品できる' do
-        expect(@item).to be_valid
-      end
+    before do
+      @item = FactoryBot.build(:item)
     end
-    context '商品出品できない場合' do
-      it '画像が空では出品できない' do
-        @item.image = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
-      end
 
-      it '商品名が空では出品できない' do
-        @item.item_name = ''
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Item name can't be blank")
+    describe '商品出品機能' do
+      context '商品出品できる場合' do
+        it '必要事項を全て過不足なく入力すると出品できる' do
+          expect(@item).to be_valid
+        end
       end
+      context '商品出品できない場合' do
+        it '画像が空では出品できない' do
+          @item.image = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Image can't be blank")
+        end
 
-      it '商品の説明が空では出品できない' do
-        @item.item_description = ''
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Item description can't be blank")
-      end
-      
-      it '商品のカテゴリーに「---」が選択されている場合は出品できない' do
-        @item.category_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
-      end
+        it '商品名が空では出品できない' do
+          @item.item_name = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Item name can't be blank")
+        end
 
-      it '商品の状態に「---」が選択されている場合は出品できない' do
-        @item.condition_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Condition can't be blank")
-      end
+        it '商品の説明が空では出品できない' do
+          @item.item_description = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Item description can't be blank")
+        end
 
-      it '配送料の負担に「---」が選択されている場合は出品できない' do
-        @item.delivery_charge_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery charge can't be blank")
-      end
+        it '商品のカテゴリーに「---」が選択されている場合は出品できない' do
+          @item.category_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Category can't be blank")
+        end
 
-      it '発送元の地域に「---」が選択されている場合は出品できない' do
-        @item.delivery_from_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery from can't be blank")
-      end
+        it '商品の状態に「---」が選択されている場合は出品できない' do
+          @item.condition_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Condition can't be blank")
+        end
 
-      it '発送までの日数に「---」が選択されている場合は出品できない' do
-        @item.delivery_time_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time can't be blank")
-      end
-      
-      it '価格が空では出品できない' do
-        @item.price = ''
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
-      end
-      
-      it '価格に半角数字以外が含まれている場合は出品できない' do
-        @item.price = '５０００'
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
-      end
+        it '配送料の負担に「---」が選択されている場合は出品できない' do
+          @item.delivery_charge_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Delivery charge can't be blank")
+        end
 
-      it '販売価格が¥300より少ないと出品できない' do
-        @item.price = 299
-        @item.valid?
-        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
-      end
+        it '発送元の地域に「---」が選択されている場合は出品できない' do
+          @item.delivery_from_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Delivery from can't be blank")
+        end
 
-      it '販売価格が¥9999999より少ないと出品できない' do
-        @item.price = 10_000_000
-        @item.valid?
-        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
-      end
+        it '発送までの日数に「---」が選択されている場合は出品できない' do
+          @item.delivery_time_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Delivery time can't be blank")
+        end
 
-      it 'ユーザーが紐付いていなければ投稿できない' do
-        @item.user = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        it '価格が空では出品できない' do
+          @item.price = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price can't be blank")
+        end
+
+        it '価格に半角数字以外が含まれている場合は出品できない' do
+          @item.price = '５０００'
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price is not a number')
+        end
+
+        it '販売価格が¥300より少ないと出品できない' do
+          @item.price = 299
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+        end
+
+        it '販売価格が¥9999999より少ないと出品できない' do
+          @item.price = 10_000_000
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+        end
+
+        it 'ユーザーが紐付いていなければ投稿できない' do
+          @item.user = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include('User must exist')
+        end
       end
     end
   end
 end
-end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,24 +52,24 @@ RSpec.describe User, type: :model do
       end
 
       it 'passwordが数字だけだと登録できない' do
-        @user.password ='11111111'
+        @user.password = '11111111'
         @user.password_confirmation = '11111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password パスワードには半角英字と半角数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include('Password パスワードには半角英字と半角数字の両方を含めて設定してください')
       end
 
       it 'passwordが英字だけだと登録できない' do
         @user.password = 'aaaaaaaa'
         @user.password_confirmation = 'aaaaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password パスワードには半角英字と半角数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include('Password パスワードには半角英字と半角数字の両方を含めて設定してください')
       end
 
       it 'passwordが全角だと登録できない' do
         @user.password = 'ああああああ'
         @user.password_confirmation = 'ああああああ'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password パスワードには半角英字と半角数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include('Password パスワードには半角英字と半角数字の両方を含めて設定してください')
       end
 
       it 'passwordとpassword_confirmationが不一致では登録できない' do


### PR DESCRIPTION
# What
商品詳細表示機能を実装

# Why
商品詳細表示にて、ユーザーのログイン有無・商品出品有無によるページとボタン（編集・削除・購入）を設定。

●ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/5ecce932a1190a013ff8ff8e991f631c

●ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/048dce84792f0a8b63ee22c7c9481401

●ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/188912403c27c6b1e505c8734182f0ab