### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,11 @@ class ItemsController < ApplicationController
   def destroy
     return unless @item.user_id == current_user.id
 
-    @item.destroy
-    redirect_to root_path
+    if @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path
     else
-      redirect_to root_path
+      render :index
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, except: [:index, :show]
 
@@ -33,6 +33,13 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    return unless @item.user_id == current_user.id
+
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
        <% if current_user == @item.user %> 
             <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>
-            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+            <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
        <% else %>
          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
        <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   get 'items/index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]  do
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
   end  
 end


### PR DESCRIPTION
# Why
商品削除機能実装のため

# What
ログインしているユーザーが自分の出品した商品を削除できるように実装

●ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/c838b39c9ba348f8b6cec6407e5e2152

  